### PR TITLE
Change license to type

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "licenses": [
     {
-      "license": "Apache-2.0",
+      "type": "Apache-2.0",
       "url": "http://github.com/rbuckton/ReflectDecorators/raw/master/LICENSE"
     }
   ],


### PR DESCRIPTION
I think "license" -> "type" is correct.
https://docs.npmjs.com/files/package.json

Related to https://github.com/twada/licensify/pull/14
