### PR TITLE
Fix Map polyfill not creating when cacheKey of -1 was previously cached

### DIFF
--- a/Reflect.ts
+++ b/Reflect.ts
@@ -1566,8 +1566,11 @@ namespace Reflect {
             "@@iterator"() { return this.entries(); }
             [iteratorSymbol]() { return this.entries(); }
             private _find(key: K, insert?: boolean): number {
-                if (this._cacheKey === key) return this._cacheIndex;
-                let index = this._keys.indexOf(key);
+                let index;
+                if (this._cacheKey === key)
+                    index = this._cacheIndex;
+                else
+                    index = this._keys.indexOf(key);
                 if (index < 0 && insert) {
                     index = this._keys.length;
                     this._keys.push(key);

--- a/Reflect.ts
+++ b/Reflect.ts
@@ -1570,13 +1570,13 @@ namespace Reflect {
                 if (this._cacheKey === key)
                     index = this._cacheIndex;
                 else
-                    index = this._keys.indexOf(key);
+                    index = this._cacheIndex = this._keys.indexOf(this._cacheKey = key);
                 if (index < 0 && insert) {
-                    index = this._keys.length;
+                    index = this._cacheIndex = this._keys.length;
                     this._keys.push(key);
                     this._values.push(undefined);
                 }
-                return this._cacheKey = key, this._cacheIndex = index;
+                return index;
             }
         };
 


### PR DESCRIPTION
Fixes #56 

I've seen the same issue in PhantomJS which also uses the Map shim.