### PR TITLE
Emit Reflect.ts to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,5 @@ test
 typings
 bower.json
 gulpfile.js
-Reflect.ts
 spec.html
 tsconfig.json


### PR DESCRIPTION
Without the file, the mapping files are quite useless