### PR TITLE
No dynamic evaluation in `/lite` mode

### DIFF
--- a/ReflectLite.ts
+++ b/ReflectLite.ts
@@ -571,16 +571,8 @@ namespace Reflect {
             };
         }
 
-        function functionThis() {
-            try { return Function("return this;")(); } catch (_) { }
-        }
-
-        function indirectEvalThis() {
-            try { return (void 0, eval)("(function() { return this; })()"); } catch (_) { }
-        }
-
-        function sloppyModeThis() {
-            return functionThis() || indirectEvalThis();
+        function sloppyModeThis(): never {
+            throw new ReferenceError("globalThis could not be found. Please polyfill globalThis before loading this module.");
         }
     })
     (function (exporter, root) {


### PR DESCRIPTION
This removes the sloppy-mode lookup for the global object from `/lite`-mode, which tried to use `new Function` or indirect eval to obtain `globalThis`. Instead users of `/lite`-mode will need to supply their own polyfill for `globalThis` if the other usual suspects (`global`, `self`, or just `this`) don't work. This behavior is consistent with `/lite`-mode's behavior of avoiding other polyfills for `Map`/`Set`/`WeakMap`.

This does not affect the default export for `reflect-metadata`.

Fixes #147
Supersedes #141