### PR TITLE
Don't use return value of crypto.getRandomValues

### DIFF
--- a/Reflect.ts
+++ b/Reflect.ts
@@ -2005,9 +2005,17 @@ namespace Reflect {
 
             function GenRandomBytes(size: number): BufferLike {
                 if (typeof Uint8Array === "function") {
-                    if (typeof crypto !== "undefined") return crypto.getRandomValues(new Uint8Array(size)) as Uint8Array;
-                    if (typeof msCrypto !== "undefined") return msCrypto.getRandomValues(new Uint8Array(size)) as Uint8Array;
-                    return FillRandomBytes(new Uint8Array(size), size);
+                    const array = new Uint8Array(size);
+                    if (typeof crypto !== "undefined") {
+                        crypto.getRandomValues(array);
+                    }
+                    else if (typeof msCrypto !== "undefined") {
+                        msCrypto.getRandomValues(array);
+                    }
+                    else {
+                        FillRandomBytes(array, size);
+                    }
+                    return array;
                 }
                 return FillRandomBytes(new Array(size), size);
             }


### PR DESCRIPTION
Per #64, old versions of Android didn't return a result from `crypto.getRandomValues`.

Supersedes #64