### PR TITLE
Fix stack overflow crash in isProviderFor

### DIFF
--- a/Reflect.ts
+++ b/Reflect.ts
@@ -1745,6 +1745,7 @@ namespace Reflect {
         }
 
         function CreateFallbackProvider(reflect: typeof Reflect): MetadataProvider {
+            const { defineMetadata, hasOwnMetadata, getOwnMetadata, getOwnMetadataKeys, deleteMetadata } = reflect;
             const metadataOwner = new _WeakMap<object, Set<string | symbol | undefined>>();
             const provider: MetadataProvider = {
                 isProviderFor(O, P) {
@@ -1752,7 +1753,7 @@ namespace Reflect {
                     if (!IsUndefined(metadataPropertySet)) {
                         return metadataPropertySet.has(P);
                     }
-                    if (reflect.getOwnMetadataKeys(O, P!).length) {
+                    if (getOwnMetadataKeys(O, P!).length) {
                         if (IsUndefined(metadataPropertySet)) {
                             metadataPropertySet = new _Set();
                             metadataOwner.set(O, metadataPropertySet);
@@ -1762,11 +1763,11 @@ namespace Reflect {
                     }
                     return false;
                 },
-                OrdinaryDefineOwnMetadata: reflect.defineMetadata,
-                OrdinaryHasOwnMetadata: reflect.hasOwnMetadata,
-                OrdinaryGetOwnMetadata: reflect.getOwnMetadata,
-                OrdinaryOwnMetadataKeys: reflect.getOwnMetadataKeys,
-                OrdinaryDeleteMetadata: reflect.deleteMetadata,
+                OrdinaryDefineOwnMetadata: defineMetadata,
+                OrdinaryHasOwnMetadata: hasOwnMetadata,
+                OrdinaryGetOwnMetadata: getOwnMetadata,
+                OrdinaryOwnMetadataKeys: getOwnMetadataKeys,
+                OrdinaryDeleteMetadata: deleteMetadata,
             };
             return provider;
         }

--- a/ReflectLite.ts
+++ b/ReflectLite.ts
@@ -1705,6 +1705,7 @@ namespace Reflect {
         }
 
         function CreateFallbackProvider(reflect: typeof Reflect): MetadataProvider {
+            const { defineMetadata, hasOwnMetadata, getOwnMetadata, getOwnMetadataKeys, deleteMetadata } = reflect;
             const metadataOwner = new _WeakMap<object, Set<string | symbol | undefined>>();
             const provider: MetadataProvider = {
                 isProviderFor(O, P) {
@@ -1712,7 +1713,7 @@ namespace Reflect {
                     if (!IsUndefined(metadataPropertySet)) {
                         return metadataPropertySet.has(P);
                     }
-                    if (reflect.getOwnMetadataKeys(O, P!).length) {
+                    if (getOwnMetadataKeys(O, P!).length) {
                         if (IsUndefined(metadataPropertySet)) {
                             metadataPropertySet = new _Set();
                             metadataOwner.set(O, metadataPropertySet);
@@ -1722,11 +1723,11 @@ namespace Reflect {
                     }
                     return false;
                 },
-                OrdinaryDefineOwnMetadata: reflect.defineMetadata,
-                OrdinaryHasOwnMetadata: reflect.hasOwnMetadata,
-                OrdinaryGetOwnMetadata: reflect.getOwnMetadata,
-                OrdinaryOwnMetadataKeys: reflect.getOwnMetadataKeys,
-                OrdinaryDeleteMetadata: reflect.deleteMetadata,
+                OrdinaryDefineOwnMetadata: defineMetadata,
+                OrdinaryHasOwnMetadata: hasOwnMetadata,
+                OrdinaryGetOwnMetadata: getOwnMetadata,
+                OrdinaryOwnMetadataKeys: getOwnMetadataKeys,
+                OrdinaryDeleteMetadata: deleteMetadata,
             };
             return provider;
         }

--- a/ReflectNoConflict.ts
+++ b/ReflectNoConflict.ts
@@ -1582,6 +1582,7 @@ function CreateMetadataProvider(registry: MetadataRegistry): MetadataProvider {
 }
 
 function CreateFallbackProvider(reflect: typeof Reflect): MetadataProvider {
+    const { defineMetadata, hasOwnMetadata, getOwnMetadata, getOwnMetadataKeys, deleteMetadata } = reflect;
     const metadataOwner = new _WeakMap<object, Set<string | symbol | undefined>>();
     const provider: MetadataProvider = {
         isProviderFor(O, P) {
@@ -1589,7 +1590,7 @@ function CreateFallbackProvider(reflect: typeof Reflect): MetadataProvider {
             if (!IsUndefined(metadataPropertySet)) {
                 return metadataPropertySet.has(P);
             }
-            if (reflect.getOwnMetadataKeys(O, P!).length) {
+            if (getOwnMetadataKeys(O, P!).length) {
                 if (IsUndefined(metadataPropertySet)) {
                     metadataPropertySet = new _Set();
                     metadataOwner.set(O, metadataPropertySet);
@@ -1599,11 +1600,11 @@ function CreateFallbackProvider(reflect: typeof Reflect): MetadataProvider {
             }
             return false;
         },
-        OrdinaryDefineOwnMetadata: reflect.defineMetadata,
-        OrdinaryHasOwnMetadata: reflect.hasOwnMetadata,
-        OrdinaryGetOwnMetadata: reflect.getOwnMetadata,
-        OrdinaryOwnMetadataKeys: reflect.getOwnMetadataKeys,
-        OrdinaryDeleteMetadata: reflect.deleteMetadata,
+        OrdinaryDefineOwnMetadata: defineMetadata,
+        OrdinaryHasOwnMetadata: hasOwnMetadata,
+        OrdinaryGetOwnMetadata: getOwnMetadata,
+        OrdinaryOwnMetadataKeys: getOwnMetadataKeys,
+        OrdinaryDeleteMetadata: deleteMetadata,
     };
     return provider;
 }

--- a/test/reflect-other.ts
+++ b/test/reflect-other.ts
@@ -25,5 +25,17 @@ for (const { name, header, context } of suites.filter(s => s.global)) {
                 assert.strictEqual(Reflect.getOwnMetadata("key", obj), "value");
             });
         });
+
+        it("isProviderFor crash", () => {
+            const { Reflect } = script(context)`
+                Reflect.defineMetadata = function() {};
+                Reflect.getOwnMetadataKeys = function() { return [] };
+                Reflect.getMetadataKeys = function() { return []; }
+                ${header}
+                exports.Reflect = Reflect;
+            `;
+            let obj = {};
+            Reflect.getMetadataKeys(obj);
+        });
     });
 }


### PR DESCRIPTION
Fixes a stack overflow in `isProvierFor` when a newer version of `reflect-metadata` is loaded after an older version of `reflect-metadata`.

Fixes #153