### PR TITLE
Add backwards-compatible exports for reflect-metadata/Reflect

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "./no-conflict": {
       "types": "./no-conflict.d.ts",
       "default": "./ReflectNoConflict.js"
-    }
+    },
+    "./Reflect": "./Reflect.js",
+    "./Reflect.js": "./Reflect.js"
   },
   "scripts": {
     "prepublishOnly": "gulp prepublish",


### PR DESCRIPTION
Even though the documentation indicates that the package should be referenced via `reflect-metadata` (except when used via `<script>`), some projects may have manual references to `reflect-metadata/Reflect` or `reflect-metadata/Reflect.js` that are now broken by the switch to using the `"exports"` field in package.json. While I recommend that users switch to using the default package export via `reflect-metadata`, this adds backwards compatibility for older imports.

Fixes #154