### PR TITLE
Ignore .github directoy for npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,4 @@ ReflectNoConflict.js.map
 spec.html
 tsconfig.json
 tsconfig-release.json
+.github


### PR DESCRIPTION
This PR changes so that the `.github` directory is not shipped in the published npm package

see https://unpkg.com/browse/reflect-metadata@0.2.1/